### PR TITLE
syntax: python expansion (${@...}) inside shell functions

### DIFF
--- a/syntax/bitbake.vim
+++ b/syntax/bitbake.vim
@@ -86,6 +86,9 @@ syn keyword bbShFakeRootFlag    fakeroot contained
 syn match bbShFuncDef           "^\(fakeroot\s*\)\?\([0-9A-Za-z_-]\+\)\(python\)\@<!\(\s*()\s*\)\({\)\@=" contains=bbShFakeRootFlag,bbFunction,bbDelimiter nextgroup=bbShFuncRegion skipwhite
 syn region bbShFuncRegion       matchgroup=bbDelimiter start="{\s*$" end="^}\s*$" keepend contained contains=@shell
 
+" Python value inside shell functions
+syn region shDeref         start=+${@+ skip=+\\$+ excludenl end=+}+ contained contains=@python
+
 " BitBake python metadata
 syn keyword bbPyFlag            python contained
 syn match bbPyFuncDef           "^\(python\s\+\)\([0-9A-Za-z_-]\+\)\?\(\s*()\s*\)\({\)\@=" contains=bbPyFlag,bbFunction,bbDelimiter nextgroup=bbPyFuncRegion skipwhite 


### PR DESCRIPTION
Python expansions inside shell functions completely broke syntax highlighting for that function...
