### PR TITLE
Allow '+' char in var flag names

### DIFF
--- a/syntax/bitbake.vim
+++ b/syntax/bitbake.vim
@@ -58,7 +58,7 @@ syn match bbVarValue            ".*$" contained contains=bbString,bbVarDeref,bbV
 syn region bbVarPyValue         start=+${@+ skip=+\\$+ end=+}+ contained contains=@python
 
 " Vars metadata flags
-syn match bbVarFlagDef          "^\([a-zA-Z0-9\-_\.]\+\)\(\[[a-zA-Z0-9\-_\.]\+\]\)\@=" contains=bbIdentifier nextgroup=bbVarFlagFlag
+syn match bbVarFlagDef          "^\([a-zA-Z0-9\-_\.]\+\)\(\[[a-zA-Z0-9\-_\.+]\+\]\)\@=" contains=bbIdentifier nextgroup=bbVarFlagFlag
 syn region bbVarFlagFlag        matchgroup=bbArrayBrackets start="\[" end="\]\s*\(=\|+=\|=+\|?=\)\@=" contained contains=bbIdentifier nextgroup=bbVarEq
 
 " Includes and requires


### PR DESCRIPTION
This fixes an issue seen in [qemu.inc in oe-core](http://git.openembedded.org/openembedded-core/tree/meta/recipes-devtools/qemu/qemu.inc#n94), where a PACKAGECONFIG for gtk+ shows up as a syntax error. This is a minimal change to fix this issue, I don't know if + should be valid in other contexts as well.
