### PR TITLE
newbb.vim: no PR anymore

### DIFF
--- a/plugin/newbb.vim
+++ b/plugin/newbb.vim
@@ -53,7 +53,6 @@ fun! NewBBTemplate()
     put ='LICENSE = \"\"' 
     put ='SECTION = \"\"'
     put ='DEPENDS = \"\"'
-    put ='PR = \"r0\"'
     put =''
     put ='SRC_URI = \"\"'
 


### PR DESCRIPTION
"PR = 0" is default, and since [1] we should don't use it anymore.

[1]: http://cgit.openembedded.org/openembedded-core/commit/?id=58ae94f1b06d0e6234413dbf9869bde85f154c85 "this commit"

Signed-off-by: Silvio Fricke <silvio.fricke@gmail.com>