### PR TITLE
newbb: correct typo

### DIFF
--- a/plugin/newbb.vim
+++ b/plugin/newbb.vim
@@ -17,7 +17,7 @@ endif
 fun! <SID>GetUserName()
     let l:user_name = system("git config --get user.name")
     if v:shell_error
-        return "Unknow User"
+        return "Unknown User"
     else
         return substitute(l:user_name, "\n", "", "")
 endfun
@@ -25,7 +25,7 @@ endfun
 fun! <SID>GetUserEmail()
     let l:user_email = system("git config --get user.email")
     if v:shell_error
-        return "unknow@user.org"
+        return "unknown@user.org"
     else
         return substitute(l:user_email, "\n", "", "")
 endfun


### PR DESCRIPTION
Substitute 'unknown' for 'unknow' wherever it is found.

Signed-off-by: Joe MacDonald <joe_macdonald@mentor.com>