### PR TITLE
add .bb and .bbclass to 'suffixesadd' to allow file jumps

### DIFF
--- a/ftplugin/bitbake.vim
+++ b/ftplugin/bitbake.vim
@@ -1,2 +1,4 @@
 set sts=4 sw=4 et
 set cms=#%s
+
+set suffixesadd+=.bb,.bbclass


### PR DESCRIPTION
Improvements in file type plugin                                                                                  
                                                                                                                  
When jumping to file inside Vim with 'gf' or 'CTRL-W g' the editor searches for the exact file name or the word  under the cursor plus extensions in suffixesadd. In order to be able to browse through all recipes and class files I added 'set suffixesadd+=.bb,.bbclass'.   