### PR TITLE
Fix name collision with indent/python.vim

### DIFF
--- a/indent/bitbake.vim
+++ b/indent/bitbake.vim
@@ -40,7 +40,7 @@ set cpo&vim
 
 let s:maxoff = 50	" maximum number of lines to look backwards for ()
 
-function GetPythonIndent(lnum)
+function GetBitbakePythonIndent(lnum)
 
   " If this line is explicitly joined: If the previous line was also joined,
   " line it up with that one, otherwise add two 'shiftwidth'
@@ -315,7 +315,7 @@ function BitbakeIndent(lnum)
     endif
 
     if index(["bbPyDefRegion", "bbPyFuncRegion"], name) != -1
-        let ret = GetPythonIndent(a:lnum)
+        let ret = GetBitbakePythonIndent(a:lnum)
         " Should normally always be indented by at least one shiftwidth; but allow
         " return of -1 (defer to autoindent) or -2 (force indent to 0)
         if ret == 0


### PR DESCRIPTION
When editing python files and bitbake files at the same time, `GetPythonIndent()` will be defined multiple times and an error message is shown.

As the version here is custom-tailored to python usage in bitbake files, rename the indent function to `GetBitbakePythonIndent()` which will probably not collide with anything else.

Fixes #24. 