### PR TITLE
bitbake.vim: Let old syntax in variable definitions work

### DIFF
--- a/syntax/bitbake.vim
+++ b/syntax/bitbake.vim
@@ -53,7 +53,7 @@ syn keyword bbExportFlag        export contained nextgroup=bbIdentifier skipwhit
 syn match bbIdentifier          "[a-zA-Z0-9\-_\.\/\+]\+" display contained
 syn match bbVarDeref            "${[a-zA-Z0-9\-_\.\/\+]\+}" contained
 syn match bbVarEq               "\(:=\|+=\|=+\|\.=\|=\.\|?=\|??=\|=\)" contained nextgroup=bbVarValue
-syn match bbVarDef              "^\(export\s*\)\?\([a-zA-Z0-9\-_:\.\/\+]\+\(:[${}a-zA-Z0-9\-_:\.\/\+]\+\)\?\)\s*\(:=\|+=\|=+\|\.=\|=\.\|?=\|??=\|=\)\@=" contains=bbExportFlag,bbIdentifier,bbVarDeref nextgroup=bbVarEq
+syn match bbVarDef              "^\(export\s*\)\?\([a-zA-Z0-9\-_:\.\/\+]\+\([_:][${}a-zA-Z0-9\-_:\.\/\+]\+\)\?\)\s*\(:=\|+=\|=+\|\.=\|=\.\|?=\|??=\|=\)\@=" contains=bbExportFlag,bbIdentifier,bbVarDeref nextgroup=bbVarEq
 syn match bbVarValue            ".*$" contained contains=bbString,bbVarDeref,bbVarPyValue
 syn region bbVarPyValue         start=+${@+ skip=+\\$+ end=+}+ contained contains=@python
 


### PR DESCRIPTION
replacing '_' with ':' meant that older syntax is not recognised anymore
so its better to accomodate for both separators

FILES:${PN} += "${datadir}/gtksourceview-4"
FILES_${PN} += "${datadir}/gtksourceview-4"

are highlighted correctly now

Signed-off-by: Khem Raj <raj.khem@gmail.com>