### PR TITLE
plugin/newbbappend: fix bb override syntax

### DIFF
--- a/plugin/newbbappend.vim
+++ b/plugin/newbbappend.vim
@@ -20,7 +20,7 @@ fun! NewBBAppendTemplate()
     set nopaste
 
     " New bbappend template
-    0 put ='FILESEXTRAPATHS_prepend := \"${THISDIR}/${PN}:\"'
+    0 put ='FILESEXTRAPATHS:prepend := \"${THISDIR}/${PN}:\"'
     2
 
     if paste == 1


### PR DESCRIPTION
`s/_prepend/:prepend/` in newbbappend.vim to match new bitbake syntax.

This is already applied in bitbake/contrib but not here.

Signed-off-by: Patrick Williams <patrick@stwcx.xyz>
