### PR TITLE
plugin: remove BufReadPost event from newbb/newbbappend autocmd

### DIFF
--- a/plugin/newbb.vim
+++ b/plugin/newbb.vim
@@ -47,14 +47,14 @@ fun! NewBBTemplate()
 
     let l:paste = &paste
     set nopaste
-    
+
     " Get the header
     call BBHeader()
 
     " New the bb template
     put ='SUMMARY = \"\"'
     put ='HOMEPAGE = \"\"'
-    put ='LICENSE = \"\"' 
+    put ='LICENSE = \"\"'
     put ='SECTION = \"\"'
     put ='DEPENDS = \"\"'
     put =''
@@ -80,7 +80,7 @@ if v:progname =~ "vimdiff"
 endif
 
 augroup NewBB
-    au BufNewFile,BufReadPost *.bb
+    au BufNewFile *.bb
                 \ if g:bb_create_on_empty |
                 \    call NewBBTemplate() |
                 \ endif

--- a/plugin/newbbappend.vim
+++ b/plugin/newbbappend.vim
@@ -38,7 +38,7 @@ if v:progname =~ "vimdiff"
 endif
 
 augroup NewBBAppend
-    au BufNewFile,BufReadPost *.bbappend
+    au BufNewFile *.bbappend
                 \ if g:bb_create_on_empty |
                 \    call NewBBAppendTemplate() |
                 \ endif


### PR DESCRIPTION
- Having BufReadPost as an autocmd event will always run the autocmd when a file is opened that matches the set file pattern.
- The BufReadPost event shouldn't be added to the NewBB or NewBBAppend autocmds as it will run on every opened bitbake file, including ones that aren't new.