### PR TITLE
Match python task append/prepend syntax

### DIFF
--- a/syntax/bitbake.vim
+++ b/syntax/bitbake.vim
@@ -91,7 +91,7 @@ syn region shDeref         start=+${@+ skip=+\\$+ excludenl end=+}+ contained co
 
 " BitBake python metadata
 syn keyword bbPyFlag            python contained
-syn match bbPyFuncDef           "^\(fakeroot\s*\)\?\(python\)\(\s\+[0-9A-Za-z_${}\-\.]\+\)\?\(\s*()\s*\)\({\)\@=" contains=bbShFakeRootFlag,bbPyFlag,bbFunction,bbVarDeref,bbDelimiter nextgroup=bbPyFuncRegion skipwhite
+syn match bbPyFuncDef           "^\(fakeroot\s*\)\?\(python\)\(\s\+[0-9A-Za-z_${}\-\.]\+\(:\(pre\|ap\)pend\)\?\)\?\(\s*()\s*\)\({\)\@=" contains=bbShFakeRootFlag,bbPyFlag,bbFunction,bbVarDeref,bbDelimiter nextgroup=bbPyFuncRegion skipwhite
 syn region bbPyFuncRegion       matchgroup=bbDelimiter start="{\s*$" end="^}\s*$" contained contains=@python
 
 " BitBake 'def'd python functions


### PR DESCRIPTION
Currently an error label is displayed on python functions with :append/prepend.
See this example from [the user manual][1]:

![image](https://github.com/kergoth/vim-bitbake/assets/438799/b5a04e0c-4437-4eb3-ac8f-6586f0ec14d6)

<details>
<summary>example.bb</summary>

```bitbake
python some_python_function () {
    d.setVar("TEXT", "Hello World")
    print d.getVar("TEXT")
}

python do_foo:prepend() {
    bb.plain("first")
}

python do_foo() {
    bb.plain("second")
}

python do_foo:append() {
    bb.plain("third")
}
```

</details>



[1]: https://docs.yoctoproject.org/bitbake/bitbake-user-manual/bitbake-user-manual-metadata.html#bitbake-style-python-functions